### PR TITLE
030_1, 030_2_function (pep8, pylint, test)

### DIFF
--- a/functios/fillnan_mst_030_1.py
+++ b/functios/fillnan_mst_030_1.py
@@ -1,0 +1,47 @@
+"""
+030-1
+以下の条件に沿って、参照dfmを元に欠損値を埋める
+- tblのvalの欠損値の時に穴埋め処理をする。
+  具体的なルールは以下の３つ（ルール２からルール４）。
+- tblのcdの値がFで始まる文字列の場合（例：F001）の場合は、
+  fmstのval値で（例：F001なので1）欠損値の穴埋めをする
+- tblのcdの値がEで始まる文字列の場合（例：E001）の場合は、
+  emstのval値で（例：E001なので4）欠損値の穴埋めをする
+- tblのcdの値の始まりがFでもEでもない場合（例：X001）は欠損値のままにしておく。
+
+for文による処理版
+行方向への繰り返し処理のため、処理が遅くなりがち
+マージ（結合）による処理ができたのでfor文による処理は不要
+コードは短く、理解しやすい
+参考程度
+"""
+
+import math
+
+
+def fillnan_mst_for(tbl, fmst, emst):
+    """
+    func
+    tblのvalがNanのとき、
+    cdが'F'で始まる時は、fmstのvalで補完埋め
+    cdが'E'で始まる時は、emstのvalで補完埋め
+    それ以外のときはNanのまま
+    In
+    tbl : columns=["cd","val"]のpd.DataFrame（穴埋め更新対象）
+    fmst : columns=["cd","val"]のpd.DataFrame（参照用）
+    emst : columns=["cd","val"]のpd.DataFrame（参照用）
+    out
+    fmst, emstを参照してNanを補完埋めしたpd.DataFrame
+    """
+    for i in range(len(tbl)):
+        # ''をNoneに置き換え
+        tbl = tbl.replace({'': None})
+        if math.isnan(tbl.loc[i, "val"]):
+            if tbl.loc[i, "cd"].startswith("F"):
+                tbl.loc[i, "val"] = fmst[
+                    fmst["cd"] == tbl.loc[i, "cd"]]["val"].values[0]
+            elif tbl.loc[i, "cd"].startswith("E"):
+                tbl.loc[i, "val"] = emst[
+                    emst["cd"] == tbl.loc[i, "cd"]]["val"].values[0]
+
+    return tbl

--- a/functios/fillnan_mst_030_2.py
+++ b/functios/fillnan_mst_030_2.py
@@ -1,0 +1,83 @@
+"""
+030-2
+以下の条件に沿って、参照dfmを元に欠損値を埋める
+- tblのvalの欠損値の時に穴埋め処理をする。
+  具体的なルールは以下の３つ（ルール２からルール４）。
+- tblのcdの値がFで始まる文字列の場合（例：F001）の場合は、
+  fmstのval値で（例：F001なので1）欠損値の穴埋めをする
+- tblのcdの値がEで始まる文字列の場合（例：E001）の場合は、
+  emstのval値で（例：E001なので4）欠損値の穴埋めをする
+- tblのcdの値の始まりがFでもEでもない場合（例：X001）は欠損値のままにしておく。
+"""
+
+import math
+import pandas as pd
+
+
+def is_not_nan(val):
+    """
+    func
+    mapメソッドのために「NaNでなければTrueを返す」関数
+    In
+    val ; NaNでないことを判定したい値
+    Out
+    bool値
+    """
+    return not math.isnan(val)
+
+
+def set_new_val(tbl_merged, x_val):
+    """
+    func
+    マージ後のdfにおいて、val列がNaNかつfmstまたはemstの値があるとき、
+    dfのnew_val列にfmstまたはemstの値を代入する
+    In
+    tbl_merged : fmst, emstをマージしたtbl
+    x_val : "f_val"または"e_val"を指定
+    Out
+    なし（tbl_mergedが直接修正される）
+    """
+    tbl_merged.loc[
+        tbl_merged["val"].map(math.isnan) & tbl_merged[x_val].map(
+            is_not_nan
+            ), "new_val"] = tbl_merged.loc[
+                tbl_merged["val"].map(math.isnan) & tbl_merged[x_val].map(
+                    is_not_nan), x_val]
+
+
+def fillnan_mst(tbl, fmst, emst):
+    """
+    func
+    tblのvalがNanのとき、
+    cdが'F'で始まる時は、fmstのvalで補完埋め
+    cdが'E'で始まる時は、emstのvalで補完埋め
+    それ以外のときはNanのまま
+    In
+    tbl : columns=["cd","val"]のpd.DataFrame（穴埋め更新対象）
+    fmst : columns=["cd","val"]のpd.DataFrame（参照用）
+    emst : columns=["cd","val"]のpd.DataFrame（参照用）
+    Out
+    fmst, emstを参照してNanを補完埋めしたpd.DataFrame
+    """
+    # ''をNoneに置き換え
+    tbl = tbl.replace({'': None})
+
+    # tblのval列と区別するためにfmst, emstのval列の列名を変更
+    fmst_fval = fmst.rename(columns={'val': 'f_val'})
+    emst_eval = emst.rename(columns={'val': 'e_val'})
+
+    # tblにfmst, emstをマージ（結合）する
+    tbl_merged = pd.merge(tbl, fmst_fval, on='cd', how='left')
+    tbl_merged = pd.merge(tbl_merged, emst_eval, on='cd', how='left')
+
+    # 各行から適切なval値を抽出し、new_val列に保存
+    set_new_val(tbl_merged, "f_val")
+    set_new_val(tbl_merged, "e_val")
+    tbl_merged.loc[tbl_merged["val"].map(is_not_nan), "new_val"] = \
+        tbl_merged.loc[tbl_merged["val"].map(is_not_nan), "val"]
+
+    # 必要な列のみを抽出し、新しいdfを作成
+    tbl = tbl_merged[["cd", "new_val"]]
+    tbl = tbl.rename(columns={'new_val': 'val'})
+
+    return tbl

--- a/functios/readme.md
+++ b/functios/readme.md
@@ -100,19 +100,120 @@ testsディレクトリで`nosetests test_pattern_fillna_int_or_float_020.py`を
 
 ## 3. 030の作成
 
-### `.py`を作成
+### `fillnan_mst_030_1.py`を作成
+
+030_1 以下の条件に沿って、参照dfmを元に欠損値を埋める
+- tblのvalの欠損値の時に穴埋め処理をする。
+  具体的なルールは以下の３つ（ルール２からルール４）。
+- tblのcdの値がFで始まる文字列の場合（例：F001）の場合は、
+  fmstのval値で（例：F001なので1）欠損値の穴埋めをする
+- tblのcdの値がEで始まる文字列の場合（例：E001）の場合は、
+  emstのval値で（例：E001なので4）欠損値の穴埋めをする
+- tblのcdの値の始まりがFでもEでもない場合（例：X001）は欠損値のままにしておく。
+
+for文による処理版
+行方向への繰り返し処理のため、処理が遅くなりがち
+マージ（結合）による処理ができたのでfor文による処理は不要
+コードは短く、理解しやすい
+参考程度
+
+主関数
+
+`def fillnan_mst_for(tbl, fmst, emst):`
+
+必要な入力データ
+
+- 参照df その１
+
+`fmst = pd.DataFrame(..)`
+
+- 参照df その２
+
+`emst = pd.DataFrame(..)`
+
+- 更新tbl
+
+`tbl = pd.DataFrame(..)`
+
+必要な内部関数
+
+`def is_not_nan(val):`
+
+`def set_new_val(tbl_merged, x_val):`
+
+【補足】
 
 ### pep8とpylintの構文チェック
 
+pep8: 問題なし
+
+pylint: 問題なし
+
 ### noseテスト
+
+testsディレクトリで`nosetests test_fillnan_mst_030_1.py`を実行
+
+- `test_fillnan_mst_for_small()`: 最初に与えられた例でfillnan_mst_for()をテスト
+    - 問題なし
+
+- `test_fillnan_mst_for_large()`: cdにバリエーションのある例でfillnan_mst_for()をテスト
+    - 問題なし
+
 
 ## 4. 030を左結合した中間DFを介して処理をし高速にできる版の作成
 
-### `.py`を作成
+### `fillnan_mst_030_2.py`を作成
+
+030_2 以下の条件に沿って、参照dfmを元に欠損値を埋める
+- tblのvalの欠損値の時に穴埋め処理をする。
+  具体的なルールは以下の３つ（ルール２からルール４）。
+- tblのcdの値がFで始まる文字列の場合（例：F001）の場合は、
+  fmstのval値で（例：F001なので1）欠損値の穴埋めをする
+- tblのcdの値がEで始まる文字列の場合（例：E001）の場合は、
+  emstのval値で（例：E001なので4）欠損値の穴埋めをする
+- tblのcdの値の始まりがFでもEでもない場合（例：X001）は欠損値のままにしておく。
+
+主関数
+
+`def fillnan_mst(tbl, fmst, emst):`
+
+必要な入力データ
+
+- 参照df その１
+
+`fmst = pd.DataFrame(..)`
+
+- 参照df その２
+
+`emst = pd.DataFrame(..)`
+
+- 更新tbl
+
+`tbl = pd.DataFrame(..)`
+
+必要な内部関数
+
+`def is_not_nan(val):`
+
+`def set_new_val(tbl_merged, x_val):`
+
+【補足】
 
 ### pep8とpylintの構文チェック
 
+pep8: 問題なし
+
+pylint: 問題なし
+
 ### noseテスト
+
+testsディレクトリで`nosetests test_fillnan_mst_030_2.py`を実行
+
+- `test_fillnan_mst_small()`: 最初に与えられた例でfillnan_mst()をテスト
+    - 問題なし
+
+- `test_fillnan_mst_large()`: cdにバリエーションのある例でfillnan_mst()をテスト
+    - 問題なし
 
 ## 5. 032の作成
 

--- a/tests/test_fillnan_mst_030_1.py
+++ b/tests/test_fillnan_mst_030_1.py
@@ -1,0 +1,172 @@
+"""
+fillnan_mst_for()関数をテスト
+"""
+
+import sys
+import os
+from nose.tools import with_setup
+import numpy as np
+import pandas as pd
+from pandas.util.testing import assert_frame_equal
+
+# functiosディレクトリのpyファイルをインポートするためにパスを追加
+PATH = os.path.dirname(os.path.abspath(__file__)).split("\\")
+PATH = "\\".join(PATH[:-1])
+sys.path.append(PATH)
+
+from functios import fillnan_mst_030_1
+
+
+class TestFillnanMst:
+    """
+    030_1のfillnan_mst_for()関数をテストするために共通に必要な値や
+    dfを設定しておく
+    """
+    # 参照df その１
+    FMST = pd.DataFrame(
+        [
+            {"cd": "F001", "val": 1},
+            {"cd": "F002", "val": 2},
+            {"cd": "F003", "val": 3}
+            ], columns=["cd", "val"]
+    )
+
+    # 参照df その２
+    EMST = pd.DataFrame(
+        [
+            {"cd": "E001", "val": 4},
+            {"cd": "E002", "val": 5},
+            {"cd": "E003", "val": 6}
+        ], columns=["cd", "val"]
+    )
+
+    def test_fillnan_mst_for_small(self):
+        """
+        最初に与えられた例でfillnan_mst_for()をテスト
+        """
+        # 更新tbl
+        test_tbl = pd.DataFrame(
+            [
+                {"cd": "F001", "val": None},
+                {"cd": "E001", "val": None},
+                {"cd": "X001", "val": None},
+                {"cd": "F001", "val": ''},
+                {"cd": "E001", "val": ''},
+                {"cd": "X001", "val": ''},
+                {"cd": "F001", "val": 100},
+                {"cd": "E001", "val": 200},
+                {"cd": "X001", "val": 300}
+            ], columns=["cd", "val"]
+        )
+
+        # 出力されて欲しいdf
+        expected_table = pd.DataFrame(
+            [
+                {"cd": "F001", "val": 1},
+                {"cd": "E001", "val": 4},
+                {"cd": "X001", "val": np.nan},
+                {"cd": "F001", "val": 1},
+                {"cd": "E001", "val": 4},
+                {"cd": "X001", "val": np.nan},
+                {"cd": "F001", "val": 100},
+                {"cd": "E001", "val": 200},
+                {"cd": "X001", "val": 300}
+            ], columns=["cd", "val"]
+        )
+
+        # expected_tableのprice列のデータ型をint型に変換
+        # PRICE_TYPE = int
+        # expected_table = expected_table.astype({"price": PRICE_TYPE})
+
+        # fillnan_mst_for関数を実行
+        result_table = fillnan_mst_030_1.fillnan_mst_for(
+            test_tbl,
+            TestFillnanMst.FMST,
+            TestFillnanMst.EMST
+            )
+
+        # pandasのdfの比較を行う
+        assert_frame_equal(result_table, expected_table)
+
+    def test_fillnan_mst_for_large(self):
+        """
+        cdにバリエーションのある例でfillnan_mst_for()をテスト
+        """
+        # 更新tbl
+        test_tbl = pd.DataFrame(
+            [
+                {"cd": "F001", "val": None},
+                {"cd": "E001", "val": None},
+                {"cd": "X001", "val": None},
+                {"cd": "F001", "val": ''},
+                {"cd": "E001", "val": ''},
+                {"cd": "X001", "val": ''},
+                {"cd": "F001", "val": 100},
+                {"cd": "E001", "val": 200},
+                {"cd": "X001", "val": 300},
+                {"cd": "F002", "val": None},
+                {"cd": "E002", "val": None},
+                {"cd": "X002", "val": None},
+                {"cd": "F002", "val": ''},
+                {"cd": "E002", "val": ''},
+                {"cd": "X002", "val": ''},
+                {"cd": "F002", "val": 100},
+                {"cd": "E002", "val": 200},
+                {"cd": "X002", "val": 300},
+                {"cd": "F003", "val": None},
+                {"cd": "E003", "val": None},
+                {"cd": "X003", "val": None},
+                {"cd": "F003", "val": ''},
+                {"cd": "E003", "val": ''},
+                {"cd": "X003", "val": ''},
+                {"cd": "F003", "val": 100},
+                {"cd": "E003", "val": 200},
+                {"cd": "X003", "val": 300}
+                ], columns=["cd", "val"]
+        )
+
+        # 出力されて欲しいdf
+        expected_table = pd.DataFrame(
+            [
+                {"cd": "F001", "val": 1},
+                {"cd": "E001", "val": 4},
+                {"cd": "X001", "val": np.nan},
+                {"cd": "F001", "val": 1},
+                {"cd": "E001", "val": 4},
+                {"cd": "X001", "val": np.nan},
+                {"cd": "F001", "val": 100},
+                {"cd": "E001", "val": 200},
+                {"cd": "X001", "val": 300},
+                {"cd": "F002", "val": 2},
+                {"cd": "E002", "val": 5},
+                {"cd": "X002", "val": np.nan},
+                {"cd": "F002", "val": 2},
+                {"cd": "E002", "val": 5},
+                {"cd": "X002", "val": np.nan},
+                {"cd": "F002", "val": 100},
+                {"cd": "E002", "val": 200},
+                {"cd": "X002", "val": 300},
+                {"cd": "F003", "val": 3},
+                {"cd": "E003", "val": 6},
+                {"cd": "X003", "val": np.nan},
+                {"cd": "F003", "val": 3},
+                {"cd": "E003", "val": 6},
+                {"cd": "X003", "val": np.nan},
+                {"cd": "F003", "val": 100},
+                {"cd": "E003", "val": 200},
+                {"cd": "X003", "val": 300}
+                ], columns=["cd", "val"]
+        )
+        # expected_tableのprice列のデータ型をint型に変換
+        # PRICE_TYPE = int
+        # expected_table = expected_table.astype({"price": PRICE_TYPE})
+
+        # fillnan_mst_for関数を実行
+        result_table = fillnan_mst_030_1.fillnan_mst_for(
+            test_tbl,
+            TestFillnanMst.FMST,
+            TestFillnanMst.EMST
+            )
+
+        # pandasのdfの比較を行う
+        assert_frame_equal(result_table, expected_table)

--- a/tests/test_fillnan_mst_030_2.py
+++ b/tests/test_fillnan_mst_030_2.py
@@ -1,0 +1,172 @@
+"""
+fillnan_mst()関数をテスト
+"""
+
+import sys
+import os
+from nose.tools import with_setup
+import numpy as np
+import pandas as pd
+from pandas.util.testing import assert_frame_equal
+
+# functiosディレクトリのpyファイルをインポートするためにパスを追加
+PATH = os.path.dirname(os.path.abspath(__file__)).split("\\")
+PATH = "\\".join(PATH[:-1])
+sys.path.append(PATH)
+
+from functios import fillnan_mst_030_2
+
+
+class TestFillnanMst:
+    """
+    030_2のfillnan_mst_for()関数をテストするために共通に必要な値や
+    dfを設定しておく
+    """
+    # 参照df その１
+    FMST = pd.DataFrame(
+        [
+            {"cd": "F001", "val": 1},
+            {"cd": "F002", "val": 2},
+            {"cd": "F003", "val": 3}
+            ], columns=["cd", "val"]
+    )
+
+    # 参照df その２
+    EMST = pd.DataFrame(
+        [
+            {"cd": "E001", "val": 4},
+            {"cd": "E002", "val": 5},
+            {"cd": "E003", "val": 6}
+        ], columns=["cd", "val"]
+    )
+
+    def test_fillnan_mst_small(self):
+        """
+        最初に与えられた例でfillnan_mst()をテスト
+        """
+        # 更新tbl
+        test_tbl = pd.DataFrame(
+            [
+                {"cd": "F001", "val": None},
+                {"cd": "E001", "val": None},
+                {"cd": "X001", "val": None},
+                {"cd": "F001", "val": ''},
+                {"cd": "E001", "val": ''},
+                {"cd": "X001", "val": ''},
+                {"cd": "F001", "val": 100},
+                {"cd": "E001", "val": 200},
+                {"cd": "X001", "val": 300}
+            ], columns=["cd", "val"]
+        )
+
+        # 出力されて欲しいdf
+        expected_table = pd.DataFrame(
+            [
+                {"cd": "F001", "val": 1},
+                {"cd": "E001", "val": 4},
+                {"cd": "X001", "val": np.nan},
+                {"cd": "F001", "val": 1},
+                {"cd": "E001", "val": 4},
+                {"cd": "X001", "val": np.nan},
+                {"cd": "F001", "val": 100},
+                {"cd": "E001", "val": 200},
+                {"cd": "X001", "val": 300}
+            ], columns=["cd", "val"]
+        )
+
+        # expected_tableのprice列のデータ型をint型に変換
+        # PRICE_TYPE = int
+        # expected_table = expected_table.astype({"price": PRICE_TYPE})
+
+        # fillnan_mst_for関数を実行
+        result_table = fillnan_mst_030_2.fillnan_mst(
+            test_tbl,
+            TestFillnanMst.FMST,
+            TestFillnanMst.EMST
+            )
+
+        # pandasのdfの比較を行う
+        assert_frame_equal(result_table, expected_table)
+
+    def test_fillnan_mst_large(self):
+        """
+        cdにバリエーションのある例でfillnan_mst()をテスト
+        """
+        # 更新tbl
+        test_tbl = pd.DataFrame(
+            [
+                {"cd": "F001", "val": None},
+                {"cd": "E001", "val": None},
+                {"cd": "X001", "val": None},
+                {"cd": "F001", "val": ''},
+                {"cd": "E001", "val": ''},
+                {"cd": "X001", "val": ''},
+                {"cd": "F001", "val": 100},
+                {"cd": "E001", "val": 200},
+                {"cd": "X001", "val": 300},
+                {"cd": "F002", "val": None},
+                {"cd": "E002", "val": None},
+                {"cd": "X002", "val": None},
+                {"cd": "F002", "val": ''},
+                {"cd": "E002", "val": ''},
+                {"cd": "X002", "val": ''},
+                {"cd": "F002", "val": 100},
+                {"cd": "E002", "val": 200},
+                {"cd": "X002", "val": 300},
+                {"cd": "F003", "val": None},
+                {"cd": "E003", "val": None},
+                {"cd": "X003", "val": None},
+                {"cd": "F003", "val": ''},
+                {"cd": "E003", "val": ''},
+                {"cd": "X003", "val": ''},
+                {"cd": "F003", "val": 100},
+                {"cd": "E003", "val": 200},
+                {"cd": "X003", "val": 300}
+                ], columns=["cd", "val"]
+        )
+
+        # 出力されて欲しいdf
+        expected_table = pd.DataFrame(
+            [
+                {"cd": "F001", "val": 1},
+                {"cd": "E001", "val": 4},
+                {"cd": "X001", "val": np.nan},
+                {"cd": "F001", "val": 1},
+                {"cd": "E001", "val": 4},
+                {"cd": "X001", "val": np.nan},
+                {"cd": "F001", "val": 100},
+                {"cd": "E001", "val": 200},
+                {"cd": "X001", "val": 300},
+                {"cd": "F002", "val": 2},
+                {"cd": "E002", "val": 5},
+                {"cd": "X002", "val": np.nan},
+                {"cd": "F002", "val": 2},
+                {"cd": "E002", "val": 5},
+                {"cd": "X002", "val": np.nan},
+                {"cd": "F002", "val": 100},
+                {"cd": "E002", "val": 200},
+                {"cd": "X002", "val": 300},
+                {"cd": "F003", "val": 3},
+                {"cd": "E003", "val": 6},
+                {"cd": "X003", "val": np.nan},
+                {"cd": "F003", "val": 3},
+                {"cd": "E003", "val": 6},
+                {"cd": "X003", "val": np.nan},
+                {"cd": "F003", "val": 100},
+                {"cd": "E003", "val": 200},
+                {"cd": "X003", "val": 300}
+                ], columns=["cd", "val"]
+        )
+        # expected_tableのprice列のデータ型をint型に変換
+        # PRICE_TYPE = int
+        # expected_table = expected_table.astype({"price": PRICE_TYPE})
+
+        # fillnan_mst_for関数を実行
+        result_table = fillnan_mst_030_2.fillnan_mst(
+            test_tbl,
+            TestFillnanMst.FMST,
+            TestFillnanMst.EMST
+            )
+
+        # pandasのdfの比較を行う
+        assert_frame_equal(result_table, expected_table)


### PR DESCRIPTION
- 以前提出したものをfillnan_mst_030_1.py, fillnan_mst_030_2.pyにして、pep8, pylintを通しました。
    - いただいていた例と拡張版の例を使用した簡単なテストコードを作成（test_fillnan_mst_030_1.py, test_fillnan_mst_030_2.py）しました。

- test_fillnan_mst_030_1.py, test_fillnan_mst_030_2.pyにpep8, pylintを通しました（注意はいくつか出ましたが、致命的ではないはずです）。

- functios/readme.mdを更新しました。