### PR TITLE
032_part_function (pep8, pylint, test)

### DIFF
--- a/functios/fillnan_mst_032_part.py
+++ b/functios/fillnan_mst_032_part.py
@@ -1,0 +1,69 @@
+"""
+032_part
+emst, fmstをマージ後のdfmについて、
+（ tbl_merged.priceがNone）　and  （lcd がEで始まる）ときに
+tbl_merged.priceにe_priceを代入
+（実際にはNoneではなくNaNに対しての処理）
+"""
+
+import math
+import numpy as np
+
+
+def is_not_nan(val):
+    """
+    func
+    mapメソッドのために「NaNでなければTrueを返す」関数
+    In
+    x : NaNでないことを判定したい値
+    Out
+    bool値
+    """
+    return not math.isnan(val)
+
+
+def fillnan_e_price(tbl_merged, cols):
+    """
+    func
+    マージ後のdfmについて、
+    （ tbl_merged.priceがNone）　and  （lcd がEで始まる）時に
+    tbl_merged.priceにe_priceを代入
+    In
+    tbl_merged : マージ後のpd.DataFrame（穴埋め更新対象）
+    cols : キーとして使用するlcd、欠損値を埋めるprice、
+           欠損値を埋める参考にするe_priceについて、
+           適切な列名をdictで指定する
+           {"lcd": "...", "price": "...", "e_price": "..."}
+    Out
+    欠損値をemstで補完埋めし、必要な列だけ抽出したpd.DataFrame
+    """
+
+    # dfm.priceの""をNaNで埋める
+    nan_replace_list = tbl_merged.columns
+    for col_name in nan_replace_list:
+        tbl_merged[col_name] = tbl_merged[col_name].replace("", np.nan)
+        tbl_merged.loc[tbl_merged[col_name].isnull(), col_name] = np.nan
+
+    # 処理に必要な列名を変数に代入
+    x_price = cols["e_price"]
+    price = cols["price"]
+    lcd = cols["lcd"]
+
+    # （ tbl_merged.priceがNone）　and  （lcd がEで始まる）ときに
+    # tbl_merged.priceにe_priceを代入
+    tbl_merged.loc[tbl_merged[price].map(math.isnan) & \
+     tbl_merged[x_price].map(is_not_nan), "new_price"] = \
+     tbl_merged.loc[tbl_merged[price].map(math.isnan) & \
+     tbl_merged[x_price].map(is_not_nan), x_price]
+
+    # それ以外のときにもとの値を置いておく
+    tbl_merged.loc[tbl_merged[price].map(is_not_nan), "new_price"] = \
+     tbl_merged.loc[tbl_merged[price].map(is_not_nan), price]
+
+    # 必要な列を抽出
+    tbl = tbl_merged[[lcd, "product", "new_price"]]
+
+    # 列名を整える
+    tbl = tbl.rename(columns={lcd: "lcd", "new_price": "price"})
+
+    return tbl

--- a/functios/readme.md
+++ b/functios/readme.md
@@ -276,12 +276,46 @@ testsディレクトリで`nosetests test_fillnan_mst_032.py`を実行
 
 ## 6. 032の一部を変更した部品作成
 
-### `.py`を作成
-マージ後、（ tbl_merged.priceがNone）　and  （lcd がEで始まる）時にtbl_merged.priceにe_priceを代入するコードの作成
+### `fillnan_mst_032_part.py`を作成
+
+032_part マージ後、（ tbl_merged.priceがNone）　and  （lcd がEで始まる）時にtbl_merged.priceにe_priceを代入するコード
+
+主関数
+
+`def fillnan_e_price(tbl_merged, cols):`
+
+必要な入力データ
+
+- 使用する列の指定
+
+`cols = {"lcd": "...", "price": "...", "e_price": "..."}`
+
+- 更新tbl
+
+`tbl_merged = pd.DataFrame(..)`
+
+必要な内部関数
+
+`def is_not_nan(val):`
+
+【補足】
+
+(2018-10-10 追加): dfm.priceの""をNaNで埋めるコードを追加
 
 ### pep8とpylintの構文チェック
 
+pep8: E127, E128, E502 の注意が出ている
+
+-> 「一行80文字」というコーディングルールに合わせるため、無視
+
+pylint: 問題なし
+
 ### noseテスト
+
+testsディレクトリで`nosetests test_fillnan_mst_032_part.py`を実行
+
+- `test_fillnan_e_price_small()`: 最初に与えられた例でfillnan_e_price()をテスト
+    - 問題なし
 
 ## 7. 032のテストコードを作成
 

--- a/tests/test_fillnan_mst_030_1.py
+++ b/tests/test_fillnan_mst_030_1.py
@@ -74,10 +74,6 @@ class TestFillnanMst:
             ], columns=["cd", "val"]
         )
 
-        # expected_tableのprice列のデータ型をint型に変換
-        # PRICE_TYPE = int
-        # expected_table = expected_table.astype({"price": PRICE_TYPE})
-
         # fillnan_mst_for関数を実行
         result_table = fillnan_mst_030_1.fillnan_mst_for(
             test_tbl,
@@ -157,9 +153,6 @@ class TestFillnanMst:
                 {"cd": "X003", "val": 300}
                 ], columns=["cd", "val"]
         )
-        # expected_tableのprice列のデータ型をint型に変換
-        # PRICE_TYPE = int
-        # expected_table = expected_table.astype({"price": PRICE_TYPE})
 
         # fillnan_mst_for関数を実行
         result_table = fillnan_mst_030_1.fillnan_mst_for(

--- a/tests/test_fillnan_mst_030_2.py
+++ b/tests/test_fillnan_mst_030_2.py
@@ -74,10 +74,6 @@ class TestFillnanMst:
             ], columns=["cd", "val"]
         )
 
-        # expected_tableのprice列のデータ型をint型に変換
-        # PRICE_TYPE = int
-        # expected_table = expected_table.astype({"price": PRICE_TYPE})
-
         # fillnan_mst_for関数を実行
         result_table = fillnan_mst_030_2.fillnan_mst(
             test_tbl,
@@ -157,9 +153,6 @@ class TestFillnanMst:
                 {"cd": "X003", "val": 300}
                 ], columns=["cd", "val"]
         )
-        # expected_tableのprice列のデータ型をint型に変換
-        # PRICE_TYPE = int
-        # expected_table = expected_table.astype({"price": PRICE_TYPE})
 
         # fillnan_mst_for関数を実行
         result_table = fillnan_mst_030_2.fillnan_mst(

--- a/tests/test_fillnan_mst_032_part.py
+++ b/tests/test_fillnan_mst_032_part.py
@@ -1,0 +1,105 @@
+"""
+fillnan_e_price()関数をテスト
+"""
+
+import sys
+import os
+from nose.tools import with_setup
+import numpy as np
+import pandas as pd
+from pandas.util.testing import assert_frame_equal
+
+# functiosディレクトリのpyファイルをインポートするためにパスを追加
+PATH = os.path.dirname(os.path.abspath(__file__)).split("\\")
+PATH = "\\".join(PATH[:-1])
+sys.path.append(PATH)
+
+from functios import fillnan_mst_032_part
+
+
+class TestFillnanMst:
+    """
+    032_partのfillnan_e_price()関数をテストするために共通に必要な値や
+    dfを設定しておく
+    """
+
+    # 列名を指定
+    cols = {"lcd": "lcd_x", "price": "price", "e_price": "e_price"}
+
+    def test_fillnan_e_price_small(self):
+        """
+        最初に与えられた例でfillnan_e_priceをテスト
+        """
+        # 更新tbl
+        test_tbl = pd.DataFrame(
+            [
+                {"lcd_x": "E001", "product": "abc", "price": 100, "e_price": 1,
+                 "not_E_lcd": "E001", "lcd_y": np.nan, "f_price": np.nan},
+                {"lcd_x": "E001", "product": "abc", "price": '', "e_price": 1,
+                 "not_E_lcd": "E001", "lcd_y": np.nan, "f_price": np.nan},
+                {"lcd_x": "E001", "product": "abc", "price": None,
+                 "e_price": 1, "not_E_lcd": "E001", "lcd_y": np.nan,
+                 "f_price": np.nan},
+                {"lcd_x": "E002", "product": "abc", "price": '', "e_price": "",
+                 "not_E_lcd": "E002", "lcd_y": np.nan, "f_price": np.nan},
+                {"lcd_x": "E002", "product": "abc", "price": None,
+                 "e_price": "", "not_E_lcd": "E002", "lcd_y": np.nan,
+                 "f_price": np.nan},
+                {"lcd_x": "E003", "product": "abc", "price": '',
+                 "e_price": np.nan, "not_E_lcd": "E003", "lcd_y": np.nan,
+                 "f_price": np.nan},
+                {"lcd_x": "E003", "product": "abc", "price": None,
+                 "e_price": np.nan, "not_E_lcd": "E003", "lcd_y": np.nan,
+                 "f_price": np.nan},
+                {"lcd_x": "F001", "product": "abc", "price": 100,
+                 "e_price": np.nan, "not_E_lcd": "001", "lcd_y": "F001",
+                 "f_price": 2},
+                {"lcd_x": "F001", "product": "abc", "price": '',
+                 "e_price": np.nan, "not_E_lcd": "001", "lcd_y": "F001",
+                 "f_price": 2},
+                {"lcd_x": "F001", "product": "abc", "price": None,
+                 "e_price": np.nan, "not_E_lcd": "001", "lcd_y": "F001",
+                 "f_price": 2},
+                {"lcd_x": "F002", "product": "abc", "price": '',
+                 "e_price": np.nan, "not_E_lcd": "002", "lcd_y": "F002",
+                 "f_price": ""},
+                {"lcd_x": "F002", "product": "abc", "price": None,
+                 "e_price": np.nan, "not_E_lcd": "002", "lcd_y": "F002",
+                 "f_price": ""},
+                {"lcd_x": "F003", "product": "abc", "price": '',
+                 "e_price": np.nan, "not_E_lcd": "003", "lcd_y": np.nan,
+                 "f_price": np.nan},
+                {"lcd_x": "F003", "product": "abc", "price": None,
+                 "e_price": np.nan, "not_E_lcd": "003", "lcd_y": np.nan,
+                 "f_price": np.nan}
+            ], columns=["lcd_x", "product", "price", "e_price", "not_E_lcd",
+                        "lcd_y", "f_price"]
+        )
+
+        # 出力されて欲しいdf
+        expected_table = pd.DataFrame(
+            [
+                {"lcd": "E001", "product": "abc", "price": 100},
+                {"lcd": "E001", "product": "abc", "price": 1},
+                {"lcd": "E001", "product": "abc", "price": 1},
+                {"lcd": "E002", "product": "abc", "price": np.nan},
+                {"lcd": "E002", "product": "abc", "price": np.nan},
+                {"lcd": "E003", "product": "abc", "price": np.nan},
+                {"lcd": "E003", "product": "abc", "price": np.nan},
+                {"lcd": "F001", "product": "abc", "price": 100},
+                {"lcd": "F001", "product": "abc", "price": np.nan},
+                {"lcd": "F001", "product": "abc", "price": np.nan},
+                {"lcd": "F002", "product": "abc", "price": np.nan},
+                {"lcd": "F002", "product": "abc", "price": np.nan},
+                {"lcd": "F003", "product": "abc", "price": np.nan},
+                {"lcd": "F003", "product": "abc", "price": np.nan}
+            ], columns=["lcd", "product", "price"]
+        )
+
+        # fillnan_e_price関数を実行
+        result_table = fillnan_mst_032_part.fillnan_e_price(
+            test_tbl,
+            TestFillnanMst.cols)
+
+        # pandasのdfの比較を行う
+        assert_frame_equal(result_table, expected_table)


### PR DESCRIPTION
- 以前提出したものをfillnan_mst_032_part.pyにして、pep8, pylintを通しました。
    - いただいていた例を使用した簡単なテストコードを作成（test_fillnan_mst_032_part.py）しました。

- test_fillnan_mst_032_part.pyにpep8, pylintを通しました（注意はいくつか出ましたが、致命的ではないはずです）。

- functios/readme.mdを更新しました。

※dfm.priceの""をNaNで埋めるコードを追加しています。