### PR TITLE
040_dfm_to_records (pep8, pylint, test)

### DIFF
--- a/functios/dfm_to_records_040.py
+++ b/functios/dfm_to_records_040.py
@@ -1,0 +1,27 @@
+"""
+040_dfm_to_records
+df = pd.daraframe(recrds)したdfを再びrecordsに戻す。
+"""
+
+import json
+
+
+def dfm_to_records(dfm):
+    """
+    func
+    df = pd.daraframe(recrds)したdfを再びrecordsに戻す
+    In
+    dfm : pd.DataFrame（recordsへの変換用）
+    Out
+    records : [{キー:値, ...},{キー:値, ...},{キー:値, ...},...]に変換されたリスト
+    columns_list : 元のdfmの列名のリスト
+    """
+    # dfmをjson形式（recordsの形）に変換
+    records = dfm.to_json(orient="records")
+    # 得られたjson文字列をリストに修正
+    records = json.loads(records)
+
+    # dfmの列名を取得
+    columns = list(dfm.columns)
+
+    return records, columns

--- a/functios/readme.md
+++ b/functios/readme.md
@@ -338,3 +338,39 @@ pep8: E402 「モジュールが一番上に来てない」という注意が出
 pylint: E0401, C0413, R0201, W0611といった注意が出ている
 
 -> functiosディレクトリにあるpyファイルをテストするためにパスを設定しているのが原因だったり、テストコードであることが原因だったりするようなので、無視
+
+
+
+
+## 8. 040の作成
+
+### `dfm_to_records_040.py`を作成
+
+040_dfmをrecordsに変換する関数を作成
+
+主関数
+
+`def dfm_to_records(dfm):`
+
+必要な入力データ
+
+- recordsに変換するdfm
+
+`dfm = pd.DataFrame(..)`
+
+必要な内部関数
+
+- 無し
+
+### pep8とpylintの構文チェック
+
+pep8: 問題なし
+
+pylint: 問題なし
+
+### noseテスト
+
+testsディレクトリで`nosetests dfm_to_records_040.py`を実行
+
+- `test_dfm_to_records()`: 14行3列のdfmでdfm_to_records()をテスト
+    - 問題なし

--- a/jupyter/032_tables.ipynb
+++ b/jupyter/032_tables.ipynb
@@ -346,7 +346,7 @@
     "\n",
     "    # price列のデータ型をint型に変換\n",
     "    price_type = int\n",
-    "    update_tbl = update_tbl.astype({\"price\": price_type})\n",
+    "    tbl = tbl.astype({\"price\": price_type})\n",
     "\n",
     "    return tbl"
    ]

--- a/tests/test_dfm_to_records_040.py
+++ b/tests/test_dfm_to_records_040.py
@@ -1,0 +1,74 @@
+"""
+dfm_to_records()関数をテスト
+"""
+
+import sys
+import os
+from nose.tools import eq_
+import pandas as pd
+
+# functiosディレクトリのpyファイルをインポートするためにパスを追加
+PATH = os.path.dirname(os.path.abspath(__file__)).split("\\")
+PATH = "\\".join(PATH[:-1])
+sys.path.append(PATH)
+
+from functios import dfm_to_records_040
+
+
+class TestDfmToRecords:
+    """
+    040のdfm_to_records()関数をテストするために共通に必要な値や
+    dfmを設定しておく
+    """
+    def test_dfm_to_records(self):
+        """
+        dfm_to_recordsをテスト
+        """
+        # 入力用dfm
+        dfm = pd.DataFrame(
+            [
+                {"lcd": "E001", "product": "abc", "price": 100},
+                {"lcd": "E001", "product": "abc", "price": ''},
+                {"lcd": "E001", "product": "abc", "price": None},
+                {"lcd": "E002", "product": "abc", "price": ''},
+                {"lcd": "E002", "product": "abc", "price": None},
+                {"lcd": "E003", "product": "abc", "price": ''},
+                {"lcd": "E003", "product": "abc", "price": None},
+                {"lcd": "F001", "product": "abc", "price": 100},
+                {"lcd": "F001", "product": "abc", "price": ''},
+                {"lcd": "F001", "product": "abc", "price": None},
+                {"lcd": "F002", "product": "abc", "price": ''},
+                {"lcd": "F002", "product": "abc", "price": None},
+                {"lcd": "F003", "product": "abc", "price": ''},
+                {"lcd": "F003", "product": "abc", "price": None}
+            ], columns=["lcd", "product", "price"]
+        )
+
+        # 出力されて欲しいrecords
+        expected_records = [
+            {"lcd": "E001", "product": "abc", "price": 100},
+            {"lcd": "E001", "product": "abc", "price": ''},
+            {"lcd": "E001", "product": "abc", "price": None},
+            {"lcd": "E002", "product": "abc", "price": ''},
+            {"lcd": "E002", "product": "abc", "price": None},
+            {"lcd": "E003", "product": "abc", "price": ''},
+            {"lcd": "E003", "product": "abc", "price": None},
+            {"lcd": "F001", "product": "abc", "price": 100},
+            {"lcd": "F001", "product": "abc", "price": ''},
+            {"lcd": "F001", "product": "abc", "price": None},
+            {"lcd": "F002", "product": "abc", "price": ''},
+            {"lcd": "F002", "product": "abc", "price": None},
+            {"lcd": "F003", "product": "abc", "price": ''},
+            {"lcd": "F003", "product": "abc", "price": None}
+        ]
+
+        # 出力されて欲しいcolumns
+        expected_columns = ["lcd", "product", "price"]
+
+        # dfm_to_records関数を実行
+        result_records, result_columns = dfm_to_records_040.dfm_to_records(
+            dfm)
+
+        # 比較を行う
+        eq_(result_records, expected_records)
+        eq_(result_columns, expected_columns)


### PR DESCRIPTION
- dfm_to_records_040.pyを作成し、pep8, pylintを通しました。
    - 14行3列のdfmを使用した簡単なテストコード（dfm_to_records_040.py）を作成しました。

- dfm_to_records_040.pyにpep8, pylintを通しました（注意はいくつか出ましたが、致命的ではないはずです）。

- functios/readme.mdを更新しました。



※032_tables.ipynbにミスがあったため、修正しています。